### PR TITLE
Change empty text messages

### DIFF
--- a/js/components/CategoriesTable.jsx
+++ b/js/components/CategoriesTable.jsx
@@ -96,12 +96,13 @@ var CategoriesTable = React.createClass({
   },
 
   render: function() {
+    var isSelf = this.props.currentUser._id === this.props.user._id;
     var error = this.state.error ? <div className="alert alert-info" role="alert">{this.state.error}</div> : '';
     var edit = '';
     var addCategory = '';
     var deleteCategory= '';
 
-    if (this.props.currentUser._id === this.props.user._id) {
+    if (isSelf) {
       if (this.state.editHover) {
         edit = <div className="editCategoriesBtn">
           <a onClick={this.handleAddClick}><span className="pencil glyphicon glyphicon-plus"></span></a>
@@ -126,7 +127,7 @@ var CategoriesTable = React.createClass({
 
     var includeReps = false;
     var repsHeader = '';
-    if (this.props.currentUser.username === this.props.user.username) {
+    if (isSelf) {
         includeReps = true;
         repsHeader = <th>Reps</th>;
     }
@@ -137,8 +138,12 @@ var CategoriesTable = React.createClass({
     var categoryRows = this.getCategoriesItems(includeReps);
     var addCategoriesText = '';
     if (length === 0) {
-      var text = 'You are not an expert for any categories yet! Click the "+" ' +
-        'in the top right to add some. You can create any categories that you do not find.';
+      if (isSelf) {
+        var text = 'You are not an expert for any categories yet! Click the "+" ' +
+          'in the top right to add some. You can create any categories that you do not find.';
+      } else {
+        var text = this.props.user.username + ' is not an expert for any categories yet.';
+      }
       addCategoriesText = <div className="add-category-text">{text}</div>;
     }
 

--- a/js/components/LinksBox.jsx
+++ b/js/components/LinksBox.jsx
@@ -8,7 +8,7 @@ var React = require('react');
 
 var LinksBox = React.createClass({
   getInitialState: function() {
-    return { showEdit: false, showInput : false, user: null };
+    return { showEdit: false, showInput : false };
   },
 
   handleMouseOver: function() {
@@ -44,9 +44,10 @@ var LinksBox = React.createClass({
   },
 
   render: function() {
+    var isSelf = this.props.currentUser._id === this.props.user._id;
     var edit = '';
     var linkInput = '';
-    if (this.props.currentUser._id == this.props.user._id) {
+    if (isSelf) {
       if (this.state.showEdit) {
         edit = <div className="editBox" onClick={this.handleClick}>
                  <button className="btn btn-default btn-small">
@@ -62,7 +63,11 @@ var LinksBox = React.createClass({
 
     var linksList = '';
     if (!this.props.user.links || this.props.user.links.length === 0) {
-      var text = 'You currently have no content displayed. Add some links so that users can check out your skills!';
+      if (isSelf) {
+        var text = 'You currently have no content displayed. Add some links so that users can check out your skills!';
+      } else {
+        var text = this.props.user.username + ' currently has no content displayed.';
+      }
       linksList = <p>{text}</p>;
     } else {
       linksList = <ul className="list-group">{this.getLinkItems()}</ul>;


### PR DESCRIPTION
Fixes #405

Only four places had text that was personalized: CategoriesTable, PortfolioTable, DefaultCategory, and Content Box.

-Content Box is changed
-CategoriesTable is changed
-PortfolioTable is always private
-DefaultCategory is removed in a separate PR